### PR TITLE
Added provisions for PushBullet ChannelTag

### DIFF
--- a/MediaBrowser.Plugins.PushBulletNotifications/Api/ServerApiEntryPoints.cs
+++ b/MediaBrowser.Plugins.PushBulletNotifications/Api/ServerApiEntryPoints.cs
@@ -51,7 +51,8 @@ namespace MediaBrowser.Plugins.PushBulletNotifications.Api
             {
                 {"type", "note"},
                 {"title", "Test Notification" },
-                {"body", "This is a test notification from MediaBrowser"}
+                {"body", "This is a test notification from MediaBrowser"},
+                {"channel_tag", options.ChannelTag}
             };
 
             var _httpRequest = new HttpRequestOptions();

--- a/MediaBrowser.Plugins.PushBulletNotifications/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Plugins.PushBulletNotifications/Configuration/PluginConfiguration.cs
@@ -19,6 +19,7 @@ namespace MediaBrowser.Plugins.PushBulletNotifications.Configuration
         public Boolean Enabled { get; set; }
         public String Token { get; set; }
         public String DeviceId { get; set; }
+        public String ChannelTag {get; set; }
         public string MediaBrowserUserId { get; set; }
     }
 

--- a/MediaBrowser.Plugins.PushBulletNotifications/Configuration/config.html
+++ b/MediaBrowser.Plugins.PushBulletNotifications/Configuration/config.html
@@ -23,6 +23,12 @@
                             Auth key for your application
                         </div>
                     </div>
+                    <div class="inputContainer">
+                        <input is="emby-input" type="text" id="txtPushBulletChannelTag" label="PushBullet channel tag:" />
+                        <div class="fieldDescription">
+                            Channel Tag to send notifications to
+                        </div>
+                    </div>
                     <div>
                         <button is="emby-button" type="button" class="raised button-cancel block" id="testNotification">
                             <span>Test Notification</span>
@@ -58,6 +64,7 @@
                         page.querySelector('#chkEnablePushBullet').checked = pushBulletConfig.Enabled || false;
                         $('#txtPushBulletAuthKey', page).val(pushBulletConfig.Token || '');
                         $('#txtPushBulletDeviceId', page).val(pushBulletConfig.DeviceId || '');
+                        $('#txtPushBulletChannelTag', page).val(pushBulletConfig.ChannelTag || '');
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -150,6 +157,7 @@
                         pushBulletConfig.Enabled = form.querySelector('#chkEnablePushBullet').checked;
                         pushBulletConfig.Token = $('#txtPushBulletAuthKey', form).val();
                         pushBulletConfig.DeviceId = $('#txtPushBulletDeviceId', form).val();
+                        pushBulletConfig.ChannelTag = $('#txtPushBulletChannelTag', form).val();
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/MediaBrowser.Plugins.PushBulletNotifications/Notifier.cs
+++ b/MediaBrowser.Plugins.PushBulletNotifications/Notifier.cs
@@ -50,10 +50,11 @@ namespace MediaBrowser.Plugins.PushBulletNotifications
                    // {"device_iden", options.DeviceId},
                     {"type", "note"},
                     {"title", request.Name},
-                    {"body", request.Description}
+                    {"body", request.Description},
+                    {"channel_tag", options.ChannelTag}
                 };
 
-            _logger.Debug("PushBullet to Token : {0} - {1} - {2}", options.Token, options.DeviceId, request.Description);
+            _logger.Debug("PushBullet to Token : {0} - {1} - {2} - {3}", options.Token, options.DeviceId, request.Description, options.ChannelTag);
             var _httpRequest = new HttpRequestOptions();
             string authInfo = options.Token;
             authInfo = Convert.ToBase64String(Encoding.UTF8.GetBytes(authInfo));


### PR DESCRIPTION
@LukePulverenti - I made some modifications that should allow people to add a channelTag to the Emby Notification.
I pulled it into VisualStudio and ran the BuildTask to generate the .dll.  I dropped that in place on my instance and everything appears to have worked!

EDIT: The UI elements require a cache flush, of course.